### PR TITLE
feat(): Add custom authentification for websockets

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/config/WebSecurityConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/config/WebSecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -25,8 +27,19 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private UserDetailsService userDetailsService;
 
     @Bean
+    public UserDetailsService userDetailsService() {
+        return super.userDetailsService();
+    }
+
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean(name = BeanIds.AUTHENTICATION_MANAGER)
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
     }
 
     @Override
@@ -47,6 +60,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/register").permitAll()
                 .antMatchers(HttpMethod.GET, "/websocket/info").permitAll()
+                .antMatchers( "/websocket/**").permitAll()
                 .anyRequest().authenticated()
                 .and().logout().logoutUrl("/logout").logoutSuccessHandler((new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))).permitAll();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs22/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs22/config/WebSocketConfig.java
@@ -1,14 +1,39 @@
 package ch.uzh.ifi.hase.soprafs22.config;
 
+import ch.uzh.ifi.hase.soprafs22.service.UserService;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final UserService userService;
+    private final AuthenticationManager authenticationManager;
+
+
+    public WebSocketConfig(UserService userService, AuthenticationManager authenticationManager) {
+        this.userService = userService;
+        this.authenticationManager = authenticationManager;
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -25,5 +50,25 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // handshake endpoint
         registry.addEndpoint("/websocket");
         registry.addEndpoint("/websocket").setAllowedOrigins("http://localhost:3000", "https://sopra-fs22-group-29-client.herokuapp.com").withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    Map<String, List<String>> nativeHeaders = (Map<String, List<String>>) message.getHeaders().get(SimpMessageHeaderAccessor.NATIVE_HEADERS);
+                    String authToken = nativeHeaders.get("Authorization").get(0).replace("Basic ", "");
+                    String decoded = new String(Base64.getDecoder().decode(authToken));
+                    String username = decoded.split(":")[0];
+                    UsernamePasswordAuthenticationToken authReq = new UsernamePasswordAuthenticationToken(decoded.split(":")[0], decoded.split(":")[1]);
+                    Authentication user = authenticationManager.authenticate(authReq);
+                    accessor.setUser(user);
+                }
+                return message;
+            }
+        });
     }
 }


### PR DESCRIPTION
The server now uses the Authentification (Basic) token sent in the CONNECT
frame, in order to authentify the user for websockets.

This solution is safe and should bring no compromises.